### PR TITLE
Check if the first group exists at all before returning

### DIFF
--- a/lib/functions.php
+++ b/lib/functions.php
@@ -136,7 +136,7 @@ function get_parent_group($group) {
 		'relationship_guid' => $group->guid,
 	));
 
-	if (is_array($parent)) {
+	if (is_array($parent) && isset($parent[0])) {
 		return $parent[0];
 	}
 


### PR DESCRIPTION
This should fix a DEBUG warning in logs, because it could be an empty array (which it is, most of the time) when not finding any parents.