### PR TITLE
Deprecated in 2.2: The config value "icon_sizes" is deprecated

### DIFF
--- a/views/default/au_subgroups/css.php
+++ b/views/default/au_subgroups/css.php
@@ -2,7 +2,7 @@
 
 namespace AU\SubGroups;
 
-$icon_sizes = elgg_get_config('icon_sizes');
+$icon_sizes = elgg_get_icon_sizes();
 $default_bg_image = elgg_get_site_url() . 'mod/' . PLUGIN_ID . '/graphics/iconbg.png';
 $background_image = elgg_trigger_plugin_hook('au_subgroups', 'bg_image', null, $default_bg_image);
 $font_size = array(


### PR DESCRIPTION
Deprecated in 2.2: The config value "icon_sizes" is deprecated. Use elgg_get_icon_sizes()
in /public_html/mod/au_subgroups/views/default/au_subgroups/css.php line 5